### PR TITLE
ADHOC: Bump versions in requirements file

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
-dbt-core==1.5.1
-dbt-bigquery==1.5.2
-pytz==2015.7
+dbt-core==1.9.3
+dbt-bigquery==1.9.3
+pytz==2025.2
 sqlfluff==${SQLFLUFF_VERSION}
 sqlfluff-templater-dbt==${SQLFLUFF_VERSION}


### PR DESCRIPTION
Upgrade dependency versions in requirements/requirements.txt:
- dbt-core to 1.9.3
- dbt-bigquery to 1.9.3
- pytz to 2025.2
